### PR TITLE
chore: 🏷️ Update cacheModifier types

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ export interface ICacheConfig {
    * Whatever is returned from the callback will be automatically stored against the chosen cacheKey in the
    * storage of the storage strategy you've chosen.
    */
-  cacheModifier?: Subject<(cachePairs: ICachePair<Observable<any>>[]) => ICachePair<Observable<any>>[]>;
+  cacheModifier?: Subject<(cachePairs: ICachePair<any>[]) => ICachePair<any>[]>;
 }
 ```
 

--- a/common/ICacheConfig.ts
+++ b/common/ICacheConfig.ts
@@ -53,5 +53,5 @@ export interface ICacheConfig {
    * Whatever is returned from the callback will be automatically stored against the chosen cacheKey in the
    * storage of the storage strategy you've chosen.
    */
-  cacheModifier?: Subject<(cachePairs: ICachePair<Observable<any>>[]) => ICachePair<Observable<any>>[]>;
+  cacheModifier?: Subject<(cachePairs: ICachePair<any>[]) => ICachePair<any>[]>;
 }

--- a/dist/cjs/common/ICacheConfig.d.ts
+++ b/dist/cjs/common/ICacheConfig.d.ts
@@ -49,5 +49,5 @@ export interface ICacheConfig {
      * Whatever is returned from the callback will be automatically stored against the chosen cacheKey in the
      * storage of the storage strategy you've chosen.
      */
-    cacheModifier?: Subject<(cachePairs: ICachePair<Observable<any>>[]) => ICachePair<Observable<any>>[]>;
+    cacheModifier?: Subject<(cachePairs: ICachePair<any>[]) => ICachePair<any>[]>;
 }

--- a/dist/esm2015/common/ICacheConfig.d.ts
+++ b/dist/esm2015/common/ICacheConfig.d.ts
@@ -49,5 +49,5 @@ export interface ICacheConfig {
      * Whatever is returned from the callback will be automatically stored against the chosen cacheKey in the
      * storage of the storage strategy you've chosen.
      */
-    cacheModifier?: Subject<(cachePairs: ICachePair<Observable<any>>[]) => ICachePair<Observable<any>>[]>;
+    cacheModifier?: Subject<(cachePairs: ICachePair<any>[]) => ICachePair<any>[]>;
 }

--- a/dist/esm5/common/ICacheConfig.d.ts
+++ b/dist/esm5/common/ICacheConfig.d.ts
@@ -49,5 +49,5 @@ export interface ICacheConfig {
      * Whatever is returned from the callback will be automatically stored against the chosen cacheKey in the
      * storage of the storage strategy you've chosen.
      */
-    cacheModifier?: Subject<(cachePairs: ICachePair<Observable<any>>[]) => ICachePair<Observable<any>>[]>;
+    cacheModifier?: Subject<(cachePairs: ICachePair<any>[]) => ICachePair<any>[]>;
 }


### PR DESCRIPTION
Technically, cacheModifier doesn't take an Observable<any> since you're working with the actual value. This updates that type to make cacheModifier more usable/type-friendly.